### PR TITLE
fixed issues on default scatter chart line style and transparency of line color

### DIFF
--- a/EPPlus/Drawing/Chart/ExcelScatterChartSerie.cs
+++ b/EPPlus/Drawing/Chart/ExcelScatterChartSerie.cs
@@ -153,11 +153,7 @@ namespace OfficeOpenXml.Drawing.Chart
                 {
                     Color c = Color.FromArgb(Convert.ToInt32(color, 16));
                     int a = getAlphaChannel(LINECOLOR_PATH);
-                    if (a != 255)
-                    {
-                        c = Color.FromArgb(a, c);
-                    }
-                    return c;
+                    return Color.FromArgb(a, c);
                 }
             }
             set

--- a/EPPlus/Drawing/ExcelDrawingBorder.cs
+++ b/EPPlus/Drawing/ExcelDrawingBorder.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
  * You may amend and distribute as you like, but don't remove this header!
  *
  * EPPlus provides server-side generation of Excel 2007/2010 spreadsheets.
@@ -171,6 +171,8 @@ namespace OfficeOpenXml.Drawing
         {
             switch (text)
             {
+                case "":
+                    return (eLineStyle)Enum.Parse(typeof(eLineStyle), "solid", true);
                 case "dash":
                 case "dot":
                 case "dashDot":


### PR DESCRIPTION
- [x] Write a detailed description of your what you have implemented or changed.
- [ ] Attach unit tests in the testproject to test implemented functionallity.
- [ ] Make sure no tests fail in the test project.
- [x] Verify that you only check in the files intended for the pull request.
- [x] Do not change dotnet version, include new dependencies unless you explicitly talked to someone in the project about doing so.

Default style specified for a situation which no `eLineStyle` passed to `TranslateLineStyle` to prevent unexpected results.

Fix applied to `ExcelScatterChartSerie.cs` to prevent full transparent lines.
